### PR TITLE
fix: 修复日记内容解析问题，正确处理包含###标题的内容

### DIFF
--- a/.github/workflows/handle-issue.yml
+++ b/.github/workflows/handle-issue.yml
@@ -70,8 +70,25 @@ jobs:
           const diaryType = extract("日记类型") || "daily";
           const diaryTitle = extract("日记标题");
 
-          // 2. 提取日记内容（多行字段）
-          const diaryContent = extract("日记内容");
+          // 2. 提取日记内容（多行字段） - 特殊处理，因为内容中可能包含 ###
+          // 找到"### 日记内容"的位置
+          const diaryContentStart = body.indexOf("### 日记内容");
+          if (diaryContentStart === -1) {
+            console.error("::error::找不到日记内容字段");
+            process.exit(1);
+          }
+          
+          // 找到"### 确认信息"的位置（日记内容结束标志）
+          const confirmInfoStart = body.indexOf("### 确认信息");
+          if (confirmInfoStart === -1) {
+            console.error("::error::找不到确认信息字段");
+            process.exit(1);
+          }
+          
+          // 提取日记内容（从"### 日记内容"后到"### 确认信息"前）
+          const diaryContent = body.substring(diaryContentStart, confirmInfoStart)
+            .replace(/^### 日记内容\s*\n/, '')  // 去除标题行
+            .trim();
 
           // 3. 获取时间
           const today = new Date().toISOString().split('T')[0];


### PR DESCRIPTION
## 问题描述

当前工作流在解析日记内容时，遇到内容中的 `###` 标题行会被截断，导致日记内容不完整。

## 修复方案

1. 特殊处理"日记内容"字段，不使用通用的正则解析
2. 使用"### 确认信息"作为日记内容的结束标志
3. 提取"### 日记内容"到"### 确认信息"之间的完整内容

## 测试方法

提交包含 `###` 标题的日记内容，验证是否能完整提取。

## 相关 Issue

- Issue #61: 首次入驻日记
- Issue #62: 补充完整日记内容